### PR TITLE
no age shaming

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
     "48": "images/icon.png",
     "128": "images/icon.png"
   },
-  "minimum_chrome_version": "114",
+  "minimum_chrome_version": "1",
   "permissions": [
     "contextMenus",
     "activeTab",


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 111 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version ___+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by it's button or storage change.)